### PR TITLE
Revise baseconvert

### DIFF
--- a/src/main/java/com/domain/redstonetools/features/commands/BaseConvertFeature.java
+++ b/src/main/java/com/domain/redstonetools/features/commands/BaseConvertFeature.java
@@ -21,14 +21,14 @@ public class BaseConvertFeature extends CommandFeature {
 
     @Override
     protected int execute(ServerCommandSource source) throws CommandSyntaxException {
-        int input;
+        long input;
         try {
-            input = Integer.parseInt(number.getValue(), fromBase.getValue());
+            input = Long.parseLong(number.getValue(), fromBase.getValue());
         } catch (NumberFormatException e) {
             throw new CommandSyntaxException(null, Text.of("Inputted number does not match the specified base"));
         }
 
-        var output = Integer.toString(input, toBase.getValue());
+        var output = Long.toString(input, toBase.getValue());
         source.sendFeedback(Text.of(output), false);
 
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/com/domain/redstonetools/features/commands/BaseConvertFeature.java
+++ b/src/main/java/com/domain/redstonetools/features/commands/BaseConvertFeature.java
@@ -10,6 +10,8 @@ import net.minecraft.text.Text;
 import static com.domain.redstonetools.features.arguments.IntegerSerializer.integer;
 import static com.domain.redstonetools.features.arguments.StringSerializer.word;
 
+import java.math.BigInteger;
+
 @Feature(name = "Base Convert", description = "Converts a number from one base to another.", command = "base")
 public class BaseConvertFeature extends CommandFeature {
     public static final Argument<Integer> fromBase = Argument
@@ -21,14 +23,14 @@ public class BaseConvertFeature extends CommandFeature {
 
     @Override
     protected int execute(ServerCommandSource source) throws CommandSyntaxException {
-        long input;
+        BigInteger input;
         try {
-            input = Long.parseLong(number.getValue(), fromBase.getValue());
+            input = new BigInteger(number.getValue(), fromBase.getValue());
         } catch (NumberFormatException e) {
             throw new CommandSyntaxException(null, Text.of("Inputted number does not match the specified base"));
         }
 
-        var output = Long.toString(input, toBase.getValue());
+        var output = input.toString(toBase.getValue());
         source.sendFeedback(Text.of(output), false);
 
         return Command.SINGLE_SUCCESS;


### PR DESCRIPTION
Solves this by using a long value instead of an integer 
```
/base 10 2147483648 2 
returns "Input number does not match the specified base" (2147483648 = 2^31)
/base 12 4bb2308a8 10
Returns the same thing 4bb2308a8 is 2^31 in base 12
This should return a more descriptive error letting the user know the inputted value is too large
```