### PR TITLE
[//read] Makes spacing exclusive

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
@@ -22,8 +22,8 @@ public class BinaryBlockReadFeature extends CommandFeature {
     );
 
     public static final Argument<Integer> spacing = Argument
-            .ofType(integer(1))
-            .withDefault(2);
+            .ofType(integer(0))
+            .withDefault(1);
     public static final Argument<BlockStateArgument> onBlock = Argument
             .ofType(blockState())
             .withDefault(LIT_LAMP_ARG);
@@ -50,7 +50,7 @@ public class BinaryBlockReadFeature extends CommandFeature {
         var pos1 = boundingBox.getPos1();
         var pos2 = boundingBox.getPos2();
         var direction = pos2.subtract(pos1).normalize();
-        var spacingVector = direction.multiply(spacing.getValue());
+        var spacingVector = direction.multiply(spacing.getValue() + 1);
 
         if (direction.getX() + direction.getBlockY() + direction.getBlockZ() > 1) {
             return Feedback.invalidUsage("The selection must have 2 axis the same");


### PR DESCRIPTION
Makes the spacing argument look at the space between blocks instead of including them